### PR TITLE
Package exports for grid map messages

### DIFF
--- a/grid_map_msgs/CMakeLists.txt
+++ b/grid_map_msgs/CMakeLists.txt
@@ -47,7 +47,10 @@ generate_messages(
 catkin_package(
     #INCLUDE_DIRS include
     #LIBRARIES
-    #CATKIN_DEPENDS std_msgs message_runtime
+    CATKIN_DEPENDS
+        geometry_msgs
+        message_runtime
+        std_msgs
     #DEPENDS
 )
 

--- a/grid_map_msgs/package.xml
+++ b/grid_map_msgs/package.xml
@@ -13,4 +13,5 @@
   <depend>message_generation</depend>
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
+  <exec_depend>message_runtime</exec_depend>
 </package>


### PR DESCRIPTION
So users of `grid_map_msgs` can depend on them.