### PR TITLE
Fix conversion to OccupancyGrid msg

### DIFF
--- a/grid_map/src/GridMapRosConverter.cpp
+++ b/grid_map/src/GridMapRosConverter.cpp
@@ -220,7 +220,7 @@ void GridMapRosConverter::toOccupancyGrid(const grid_map::GridMap& gridMap,
       value = cellMin + min(max(0.0f, value), 1.0f) * cellRange;
     // Occupancy grid claims to be row-major order, but it does not seem that way.
     // http://docs.ros.org/api/nav_msgs/html/msg/OccupancyGrid.html.
-    unsigned int index = get1dIndexFrom2dIndex(*iterator, gridMap.getSize(), false);
+    unsigned int index = get1dIndexFrom2dIndex(iterator.getUnwrappedIndex(), gridMap.getSize(), false);
     occupancyGrid.data[index] = value;
   }
 }

--- a/grid_map/test/GridMapTest.cpp
+++ b/grid_map/test/GridMapTest.cpp
@@ -81,3 +81,27 @@ TEST(RosbagHandling, saveLoadWithTime)
     EXPECT_DOUBLE_EQ(gridMapIn.at(layer, *iterator), gridMapOut.at(layer, *iterator));
   }
 }
+
+TEST(ToOccupancyGrid, toOccupancyGridWithMove)
+{
+  grid_map::GridMap map;
+  map.setGeometry(grid_map::Length(8.1, 5.1), 0.5, grid_map::Position(0.0, 0.0));
+  map.add("layer", 1.0);
+
+  // convert to OccupancyGrid msg
+  nav_msgs::OccupancyGrid occupancyGrid;
+  grid_map::GridMapRosConverter::toOccupancyGrid(map, "layer", 0.0, 1.0, occupancyGrid);
+
+  // expect the (0, 0) cell to have value 100
+  EXPECT_DOUBLE_EQ(100.0, occupancyGrid.data[0]);
+
+  // move the map, so the cell (0, 0) will move to unobserved space
+  map.move(grid_map::Position(1.0, 1.0));
+
+  // convert again to OGM
+  nav_msgs::OccupancyGrid occupancyGridNew;
+  grid_map::GridMapRosConverter::toOccupancyGrid(map, "layer", 0.0, 1.0, occupancyGridNew);
+
+  // Now the (0, 0) cell should be unobserved (-1.0)
+  EXPECT_DOUBLE_EQ(-1.0, occupancyGridNew.data[0]);
+}


### PR DESCRIPTION
* Use the unwrapped index when converting to one dimensional matrix indexing.
* Add a test case that demonstrates the above situation. The test should fail
  if used without the unwrapped index.
* The bug only appears if the map has been moved before the conversion. (so there is an offset to the circular buffer)

The test case only tests for this specific bug. Let me know if I should add more tests or if I should discard it altogether. 