### PR TITLE
Const correctness for getSubmap

### DIFF
--- a/grid_map_core/include/grid_map_core/GridMap.hpp
+++ b/grid_map_core/include/grid_map_core/GridMap.hpp
@@ -275,7 +275,7 @@ class GridMap
    * @return submap (is empty if success is false).
    */
   GridMap getSubmap(const grid_map::Position& position, const grid_map::Length& length,
-                    bool& isSuccess);
+                    bool& isSuccess) const;
 
   /*!
    * Gets a submap from the map. The requested submap is specified with the requested
@@ -287,7 +287,7 @@ class GridMap
    * @return submap (is empty if success is false).
    */
   GridMap getSubmap(const grid_map::Position& position, const grid_map::Length& length,
-                    grid_map::Index& indexInSubmap, bool& isSuccess);
+                    grid_map::Index& indexInSubmap, bool& isSuccess) const;
 
   /*!
    * Move the grid map w.r.t. to the grid map frame. Use this to move the grid map

--- a/grid_map_core/src/GridMap.cpp
+++ b/grid_map_core/src/GridMap.cpp
@@ -261,14 +261,14 @@ bool GridMap::getVector(const std::string& layerPrefix, const grid_map::Index& i
 }
 
 GridMap GridMap::getSubmap(const grid_map::Position& position, const grid_map::Length& length,
-                           bool& isSuccess)
+                           bool& isSuccess) const
 {
   Index index;
   return getSubmap(position, length, index, isSuccess);
 }
 
 GridMap GridMap::getSubmap(const grid_map::Position& position, const grid_map::Length& length,
-                           grid_map::Index& indexInSubmap, bool& isSuccess)
+                           grid_map::Index& indexInSubmap, bool& isSuccess) const
 {
   // Submap the generate.
   GridMap submap(layers_);


### PR DESCRIPTION
So we can use it when grid maps are passed in as const references to functions.