### PR TITLE
getIndexFromPosition() should not return index larger than bufferSize

### DIFF
--- a/grid_map_core/src/GridMapMath.cpp
+++ b/grid_map_core/src/GridMapMath.cpp
@@ -152,7 +152,7 @@ bool checkIfPositionWithinMap(const Eigen::Vector2d& position,
   Vector2d positionTransformed = getMapFrameToBufferOrderTransformation().cast<double>() * (position - mapPosition - offset);
 
   if (positionTransformed.x() >= 0.0 && positionTransformed.y() >= 0.0
-      && positionTransformed.x() <= mapLength(0) && positionTransformed.y() <= mapLength(1)) {
+      && positionTransformed.x() < mapLength(0) && positionTransformed.y() < mapLength(1)) {
     return true;
   }
   return false;

--- a/grid_map_core/test/GridMapMathTest.cpp
+++ b/grid_map_core/test/GridMapMathTest.cpp
@@ -133,6 +133,10 @@ TEST(IndexFromPosition, EdgeCases)
   EXPECT_TRUE(getIndexFromPosition(index, Vector2d(-0.5 - DBL_EPSILON, -DBL_EPSILON), mapLength, mapPosition, resolution, bufferSize));
   EXPECT_EQ(2, index(0));
   EXPECT_EQ(1, index(1));
+
+  EXPECT_TRUE(getIndexFromPosition(index, Vector2d(-1.5, 1.0), mapLength, mapPosition, resolution, bufferSize));
+  EXPECT_TRUE((index >= 0).all());
+  EXPECT_TRUE(index(0) < bufferSize(0) && index(1) < bufferSize(1));
 }
 
 TEST(IndexFromPosition, CircularBuffer)

--- a/grid_map_core/test/GridMapMathTest.cpp
+++ b/grid_map_core/test/GridMapMathTest.cpp
@@ -134,9 +134,7 @@ TEST(IndexFromPosition, EdgeCases)
   EXPECT_EQ(2, index(0));
   EXPECT_EQ(1, index(1));
 
-  EXPECT_TRUE(getIndexFromPosition(index, Vector2d(-1.5, 1.0), mapLength, mapPosition, resolution, bufferSize));
-  EXPECT_TRUE((index >= 0).all());
-  EXPECT_TRUE(index(0) < bufferSize(0) && index(1) < bufferSize(1));
+  EXPECT_FALSE(getIndexFromPosition(index, Vector2d(-1.5, 1.0), mapLength, mapPosition, resolution, bufferSize));
 }
 
 TEST(IndexFromPosition, CircularBuffer)
@@ -187,8 +185,8 @@ TEST(checkIfPositionWithinMap, EdgeCases)
   Array2d mapLength(2.0, 3.0);
   Vector2d mapPosition(0.0, 0.0);
 
-  EXPECT_TRUE(checkIfPositionWithinMap(Vector2d(1.0, -1.5), mapLength, mapPosition));
-  EXPECT_TRUE(checkIfPositionWithinMap(Vector2d(-1.0, 1.5), mapLength, mapPosition));
+  EXPECT_FALSE(checkIfPositionWithinMap(Vector2d(1.0, -1.5), mapLength, mapPosition));
+  EXPECT_FALSE(checkIfPositionWithinMap(Vector2d(-1.0, 1.5), mapLength, mapPosition));
   EXPECT_FALSE(checkIfPositionWithinMap(Vector2d(1.0 + DBL_EPSILON, 1.0), mapLength, mapPosition));
   EXPECT_TRUE(checkIfPositionWithinMap(Vector2d((2.0 + DBL_EPSILON) / 2.0, 1.0), mapLength, mapPosition));
   EXPECT_FALSE(checkIfPositionWithinMap(Vector2d(0.5, -1.5 - (2.0 * DBL_EPSILON)), mapLength, mapPosition));


### PR DESCRIPTION
In my first commit I added a test case that tests the return value of `getIndexFromPosition()` when a position right on the edge is given. Turns out that the function returns `true` and the returned index is invalid (index is equal to bufferSize). I noticed that `checkIfPositionWithinMap()` accepts positions that are exactly on the edge of the map but when the index is generated there is no check to validate that the index is still in range.

My solution was to modify `checkIfPositionWithinMap()` and not accept positions on the edge of the map. It seems that this change doesn't affect anything else.

Another solution (if it is desired to accept edge positions) would be to make sure that the returned index will be in-bounds, in similar fashion as the `limitPositionToRange()` does. In this case, the test that I added in my first commit should pass.

Since I am not sure about the desired behavior of `checkIfPositionWithinMap()` regarding edge cases, let me know if something else is indeed affected by this change.