### PR TITLE
Method for setting the position

### DIFF
--- a/grid_map_core/include/grid_map_core/GridMap.hpp
+++ b/grid_map_core/include/grid_map_core/GridMap.hpp
@@ -71,6 +71,12 @@ class GridMap
   void setGeometry(const SubmapGeometry& geometry);
 
   /*!
+   * Set the position of the grid map.
+   * @param position the 2d position of the grid map in the grid map frame [m].
+   */
+  void setPosition(const Position& position) { position_ = position; }
+
+  /*!
    * Add a new empty data layer.
    * @param layer the name of the layer.
    * @value value the value to initialize the cells with.


### PR DESCRIPTION
Right now the only place to set the position seems to be via `setGeometry`, which takes care of cleaning out all the layers etc.

We have a use case where the map width and height are fixed, and an update can happen just by writing into existing storage which is much faster than deleting it all and recreating. However, it does need a way to be able to update the position which was not hitherto possible.

Am I missing something in the usage of the library, or have you not used it in this way before?