### PR TITLE
Visualise flat point clouds

### DIFF
--- a/grid_map_ros/include/grid_map_ros/GridMapRosConverter.hpp
+++ b/grid_map_ros/include/grid_map_ros/GridMapRosConverter.hpp
@@ -77,9 +77,12 @@ class GridMapRosConverter
    * additional fields.
    * @param[in] gridMap the grid map object.
    * @param[in] pointLayer the type that is transformed to points.
+   * @param[in] flat flatCloud, set z = 0 and values in the channels (useful for 2d maps in rviz).
    * @param[out] pointCloud the message to be populated.
    */
-  static void toPointCloud(const grid_map::GridMap& gridMap, const std::string& pointLayer,
+  static void toPointCloud(const grid_map::GridMap& gridMap,
+                           const std::string& pointLayer,
+                           const bool& flatCloud,
                            sensor_msgs::PointCloud2& pointCloud);
 
   /*!
@@ -89,10 +92,14 @@ class GridMapRosConverter
    * @param[in] gridMap the grid map object.
    * @param[in] layers the layers that should be added as fields to the point cloud. Must include the pointLayer.
    * @param[in] pointLayer the layer that is transformed to points.
+   * @param[in] flatCloud cloud, set z = 0 and values in the channels (useful for 2d maps in rviz).
    * @param[out] pointCloud the message to be populated.
    */
-  static void toPointCloud(const grid_map::GridMap& gridMap, const std::vector<std::string>& layers,
-                           const std::string& pointLayer, sensor_msgs::PointCloud2& pointCloud);
+  static void toPointCloud(const grid_map::GridMap& gridMap,
+                           const std::vector<std::string>& layers,
+                           const std::string& pointLayer,
+                           const bool& flatCloud,
+                           sensor_msgs::PointCloud2& pointCloud);
 
   /*!
    * Converts an occupancy grid message to a layer of a grid map.

--- a/grid_map_ros/src/GridMapRosConverter.cpp
+++ b/grid_map_ros/src/GridMapRosConverter.cpp
@@ -8,7 +8,7 @@
 
 #include "grid_map_ros/GridMapRosConverter.hpp"
 #include "grid_map_ros/GridMapMsgHelpers.hpp"
- 
+
 #include <grid_map_core/grid_map_core.hpp>
 
 // ROS
@@ -99,14 +99,16 @@ void GridMapRosConverter::toMessage(const grid_map::GridMap& gridMap, const std:
 
 void GridMapRosConverter::toPointCloud(const grid_map::GridMap& gridMap,
                                        const std::string& pointLayer,
+                                       const bool& flatCloud,
                                        sensor_msgs::PointCloud2& pointCloud)
 {
-  toPointCloud(gridMap, gridMap.getLayers(), pointLayer, pointCloud);
+  toPointCloud(gridMap, gridMap.getLayers(), pointLayer, flatCloud, pointCloud);
 }
 
 void GridMapRosConverter::toPointCloud(const grid_map::GridMap& gridMap,
                                        const std::vector<std::string>& layers,
                                        const std::string& pointLayer,
+                                       const bool& flatCloud,
                                        sensor_msgs::PointCloud2& pointCloud)
 {
   // Header.
@@ -122,6 +124,9 @@ void GridMapRosConverter::toPointCloud(const grid_map::GridMap& gridMap,
       fieldNames.push_back("x");
       fieldNames.push_back("y");
       fieldNames.push_back("z");
+      if ( flatCloud ) {
+        fieldNames.push_back(layer);
+      }
     } else if (layer == "color") {
       fieldNames.push_back("rgb");
     } else {
@@ -172,7 +177,7 @@ void GridMapRosConverter::toPointCloud(const grid_map::GridMap& gridMap,
       } else if (iterator.first == "y") {
         *iterator.second = (float) position.y();
       } else if (iterator.first == "z") {
-        *iterator.second = (float) position.z();
+        *iterator.second = flatCloud ? 0.0 : (float) position.z();
       } else if (iterator.first == "rgb") {
         *iterator.second = gridMap.at("color", *mapIterator);
       } else {

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/PointCloudVisualization.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/PointCloudVisualization.hpp
@@ -58,6 +58,8 @@ class PointCloudVisualization : public VisualizationBase
 
   //! Type that is transformed to points.
   std::string layer_;
+  //! Generate a flat point cloud, i.e. z=0 and values of the layer in the channels.
+  bool flat_cloud_;
 };
 
 } /* namespace */

--- a/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationBase.hpp
+++ b/grid_map_visualization/include/grid_map_visualization/visualizations/VisualizationBase.hpp
@@ -92,6 +92,14 @@ class VisualizationBase
    */
   bool getParam(const std::string&name, int& value);
 
+  /*!
+   * Get a visualization parameter as a boolean.
+   * @param[in] name the name of the parameter
+   * @param[out] value the boolean to set with the value.
+   * @return true if parameter was found, false otherwise.
+   */
+  bool getParam(const std::string& name, bool& value);
+
   //! ROS nodehandle.
   ros::NodeHandle& nodeHandle_;
 

--- a/grid_map_visualization/src/visualizations/PointCloudVisualization.cpp
+++ b/grid_map_visualization/src/visualizations/PointCloudVisualization.cpp
@@ -15,6 +15,8 @@ namespace grid_map_visualization {
 
 PointCloudVisualization::PointCloudVisualization(ros::NodeHandle& nodeHandle, const std::string& name)
     : VisualizationBase(nodeHandle, name)
+    , layer_("")
+    , flat_cloud_(false)
 {
 }
 
@@ -29,6 +31,8 @@ bool PointCloudVisualization::readParameters(XmlRpc::XmlRpcValue& config)
     ROS_ERROR("PointCloudVisualization with name '%s' did not find a 'layer' parameter.", name_.c_str());
     return false;
   }
+  // optional parameter - default set by constructor
+  getParam("flat", flat_cloud_);
   return true;
 }
 
@@ -46,7 +50,7 @@ bool PointCloudVisualization::visualize(const grid_map::GridMap& map)
     return false;
   }
   sensor_msgs::PointCloud2 pointCloud;
-  grid_map::GridMapRosConverter::toPointCloud(map, layer_, pointCloud);
+  grid_map::GridMapRosConverter::toPointCloud(map, layer_, flat_cloud_, pointCloud);
   publisher_.publish(pointCloud);
   return true;
 }

--- a/grid_map_visualization/src/visualizations/VisualizationBase.cpp
+++ b/grid_map_visualization/src/visualizations/VisualizationBase.cpp
@@ -78,6 +78,15 @@ bool VisualizationBase::getParam(const std::string& name, float& value)
   return isSuccess;
 }
 
+bool VisualizationBase::getParam(const std::string& name, bool& value)
+{
+  StringMap::iterator it = parameters_.find(name);
+  if (it == parameters_.end()) return false;
+  if (it->second.getType() != XmlRpc::XmlRpcValue::TypeBoolean) return false;
+  value = it->second;
+  return true;
+}
+
 bool VisualizationBase::getParam(const std::string&name, int& value)
 {
   StringMap::iterator it = parameters_.find(name);


### PR DESCRIPTION
For double maps, converting to an occupancy grid map is a right nuisance inasmuch as you have to take care to convert values within 'proper' cost value bounds.

This PR provides a way to construct a 'flat' point cloud, that will the subsequently show the values in the layer via the colour derived from the grid map values stored in a channel.

Example yaml for the visualization node:

```
grid_map_topic: /planner/potential_grid_map
grid_map_visualizations:
  - name: potentials
    type: point_cloud
    params:
      layer: normalised
      flat: true
```

Some points to note:

* This changes the `toPointCloud` api, could drop the boolean down and give it a default argument, but that would alter the style of the rest of the functions for which `const` args always precede.

* Should the visualisation dump *all* other layers into the channels by default? Via the yaml, the impression is that I'm instructing it only to dump one layer. 
