### PR TITLE
Type traits for GridMap

### DIFF
--- a/grid_map_core/include/grid_map_core/GridMap.hpp
+++ b/grid_map_core/include/grid_map_core/GridMap.hpp
@@ -39,6 +39,10 @@ class SubmapGeometry;
 class GridMap
 {
  public:
+  // type traits for use with template methods/classes using GridMap as a template parameter
+  typedef grid_map::Matrix::Scalar DataType; /*!< Storage element type for this map. */
+  typedef grid_map::Matrix Matrix;           /*!< Storage container type for this map. */
+
   /*!
    * Constructor.
    * @param layers a vector of strings containing the definition/description of the data layer.


### PR DESCRIPTION
Useful for pulling the data and container types from the class if it has been passed as a template parameter to a template method/class. 