### PR TITLE
Costmap 2d Converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Features:
 * **Efficient map re-positioning:** Data storage is implemented as two-dimensional circular buffer. This allows for non-destructive shifting of the map's position (e.g. to follow the robot) without copying data in memory.
 * **Based on Eigen:** Grid map data is stored as [Eigen] data types. Users can apply available Eigen algorithms directly to the map data for versatile and efficient data manipulation.
 * **Convenience functions:** Several helper methods allow for convenient and memory safe cell data access. For example, iterator functions for rectangular, circular, polygonal regions and lines are implemented.
-* **ROS interface:** Grid maps can be directly converted to and from ROS message types such as PointCloud2, OccupancyGrid, GridCells, and our custom GridMap message.
+**ROS interface:** Grid maps can be directly converted to and from ROS message types such as PointCloud2, OccupancyGrid, GridCells, and our custom GridMap message. This package also contains compatibility with [costmap_2d](http://wiki.ros.org/costmap_2d).
 * **OpenCV interface:** Grid maps can be seamlessly converted from and to [OpenCV] image types to make use of the tools provided by [OpenCV].
 * **Visualizations:** The *grid_map_rviz_plugin* renders grid maps as 3d surface plots (height maps) in [RViz]. Additionally, the *grid_map_visualization* package helps to visualize grid maps as point clouds, occupancy grids, grid cells etc.
 

--- a/grid_map_core/include/grid_map_core/GridMap.hpp
+++ b/grid_map_core/include/grid_map_core/GridMap.hpp
@@ -39,6 +39,10 @@ class SubmapGeometry;
 class GridMap
 {
  public:
+  // type traits for use with template methods/classes using GridMap as a template parameter
+  typedef grid_map::Matrix::Scalar DataType; /*!< Storage element type for this map. */
+  typedef grid_map::Matrix Matrix;           /*!< Storage container type for this map. */
+
   /*!
    * Constructor.
    * @param layers a vector of strings containing the definition/description of the data layer.

--- a/grid_map_ros/CHANGELOG.rst
+++ b/grid_map_ros/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog for package grid_map_ros
 
 Forthcoming
 -----------
+* Added conversion for Costmap2D from ROS Navigation.
+* Contributors: Peter Fankhauser, Stefan Kohlbrecher, Daniel Stonier
 
 1.4.1 (2016-10-23)
 ------------------

--- a/grid_map_ros/CMakeLists.txt
+++ b/grid_map_ros/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
   cv_bridge
   rosbag
   costmap_2d
+  tf
   visualization_msgs
 )
 
@@ -48,6 +49,7 @@ catkin_package(
     cv_bridge
     rosbag
     costmap_2d
+    tf
     visualization_msgs
   DEPENDS
     #Eigen3
@@ -105,7 +107,12 @@ install(
 if(CATKIN_ENABLE_TESTING)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 ## Add gtest based cpp test target and link libraries
-catkin_add_gtest(${PROJECT_NAME}-test test/test_grid_map_ros.cpp test/GridMapRosTest.cpp)
+catkin_add_gtest(
+  ${PROJECT_NAME}-test
+  test/test_grid_map_ros.cpp
+  test/GridMapRosTest.cpp
+  test/Costmap2DConverterTest.cpp
+)
 endif()
 
 if(TARGET ${PROJECT_NAME}-test)

--- a/grid_map_ros/CMakeLists.txt
+++ b/grid_map_ros/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   cv_bridge
   rosbag
+  costmap_2d
   visualization_msgs
 )
 
@@ -39,11 +40,14 @@ catkin_package(
     roscpp
     grid_map_core
     grid_map_msgs
+    grid_map_cv
     sensor_msgs
     nav_msgs
     std_msgs
     geometry_msgs
     cv_bridge
+    rosbag
+    costmap_2d
     visualization_msgs
   DEPENDS
     #Eigen3

--- a/grid_map_ros/include/grid_map_ros/Costmap2DConverter.hpp
+++ b/grid_map_ros/include/grid_map_ros/Costmap2DConverter.hpp
@@ -1,0 +1,197 @@
+/**
+ * @file /cost_map_ros/include/cost_map_ros/costmap_2d_converter.hpp
+ */
+/*****************************************************************************
+** Ifdefs
+*****************************************************************************/
+
+#ifndef grid_map_ros_COSTMAP_2D_CONVERTER_HPP_
+#define grid_map_ros_COSTMAP_2D_CONVERTER_HPP_
+
+/*****************************************************************************
+** Includes
+*****************************************************************************/
+
+#include <costmap_2d/costmap_2d.h>
+#include <costmap_2d/costmap_2d_ros.h>
+#include <vector>
+
+/*****************************************************************************
+** Namespaces
+*****************************************************************************/
+
+namespace grid_map {
+
+/*****************************************************************************
+** Cost Translation Tables
+*****************************************************************************/
+
+/**
+ * @brief Direct cost translations for costmap_2d -> cost/grid maps.
+ *
+ * This maps the cost directly, simply casting from the underlying
+ * unsigned char to whatever onto float fields between 0.0 and 100.0 with
+ * reserved values allocated for the costmap_2d
+ */
+class Costmap2DDirectTranslationTable {
+public:
+  Costmap2DDirectTranslationTable() {}
+
+  template<typename DataType>
+  void apply(std::vector<DataType>& cost_translation_table) const {
+    cost_translation_table.resize(256);
+    for (unsigned int i = 0; i < cost_translation_table.size(); ++i ) {
+      cost_translation_table[i] = static_cast<DataType>(i);
+    }
+  }
+};
+
+/**
+ * @brief Cost translations to [0, 100] for costmap_2d -> cost/grid maps
+ *
+ * This maps the cost onto float fields between 0.0 and 100.0 with
+ * reserved values allocated for the costmap_2d
+ */
+class Costmap2DCenturyTranslationTable {
+public:
+  Costmap2DCenturyTranslationTable() {}
+
+  void apply(std::vector<float>& cost_translation_table) const {
+    cost_translation_table.resize(256);
+    cost_translation_table[0] = 0.0;     // costmap_2d::FREE_SPACE;
+    cost_translation_table[253] = 99.0;  // costmap_2d::INSCRIBED_INFLATED_OBSTACLE;
+    cost_translation_table[254] = 100.0; // costmap_2d::LETHAL_OBSTACLE
+    cost_translation_table[255] = -1.0;  // costmap_2d::NO_INFORMATION
+
+    // Regular cost values scale the range 1 to 252 (inclusive) to fit
+    // into 1 to 98 (inclusive).
+    for (int i = 1; i < 253; i++) {
+      cost_translation_table[i] = char(1 + (97 * (i - 1)) / 251);
+    }
+  }
+};
+
+template<typename DataType>
+class Costmap2DDefaultTranslationTable : public Costmap2DDirectTranslationTable {};
+
+template<>
+class Costmap2DDefaultTranslationTable<float> : public Costmap2DCenturyTranslationTable {};
+
+/*****************************************************************************
+** Converter
+*****************************************************************************/
+
+template<typename MapType>
+class Costmap2DConverter
+{
+public:
+  /**
+   * @brief Default constructor
+   * 
+   * Initiliases the cost translation table with the default policy for the template
+   * map type class.
+   **/
+  Costmap2DConverter()
+  {
+    initializeCostTranslationTable(Costmap2DDefaultTranslationTable<typename MapType::DataType>());
+  }
+
+  /**
+   * @brief Initialise the cost translation table with the user specified translation table functor.
+   * 
+   * @param translation_table : user provided translation table
+   */
+  template <typename TranslationTable>
+  Costmap2DConverter(const TranslationTable& translation_table)
+  {
+    initializeCostTranslationTable(translation_table);
+  }
+  
+  virtual ~Costmap2DConverter()
+  {
+  }
+
+  void initializeFromCostmap2d(costmap_2d::Costmap2DROS& costmap2d, MapType& outputMap)
+  {
+    initializeFromCostmap2d(*(costmap2d.getCostmap()), outputMap);
+    outputMap.setFrameId(costmap2d.getGlobalFrameID());
+  }
+
+  void initializeFromCostmap2d(const costmap_2d::Costmap2D& costmap2d, MapType& outputMap)
+  {
+    const double resolution = costmap2d.getResolution();
+    Length length(costmap2d.getSizeInCellsX()*resolution, costmap2d.getSizeInCellsY()*resolution);
+    Position position(costmap2d.getOriginX(), costmap2d.getOriginY());
+    // Different conventions.
+    position += Position(0.5 * length);
+    outputMap.setGeometry(length, resolution, position);
+  }
+
+  /**
+   * @brief Load the costmap2d into the specified layer.
+   * 
+   * @param costmap2d : from this costmap type object
+   * @param layer : name of the layer to insert
+   * @param outputMap : to this costmap type object
+   * 
+   * @warning this does not lock the costmap2d object, you should take care to do so from outside this function.
+   **/
+  bool addLayerFromCostmap2d(const costmap_2d::Costmap2D& costmap2d,
+                             const std::string& layer,
+                             MapType& outputMap)
+  {
+    // Check compliance.
+    Size size(costmap2d.getSizeInCellsX(), costmap2d.getSizeInCellsY());
+    if ((outputMap.getSize() != size).any()) {
+      ROS_ERROR("Costmap2D and output map have different sizes!");
+      return false;
+    }
+    if (!outputMap.getStartIndex().isZero()) {
+      ROS_ERROR("CostmapConverter::fromCostmap2d() does not support non-zero start indices!");
+      return false;
+    }
+    // Copy data.
+    // Reverse iteration is required because of different conventions
+    // between Costmap2d and grid map.
+    typename MapType::Matrix data(size(0), size(1));
+    const size_t nCells = outputMap.getSize().prod();
+    for (size_t i = 0, j = nCells - 1; i < nCells; ++i, --j) {
+      const unsigned char cost = costmap2d.getCharMap()[j];
+      data(i) = (float) costTranslationTable_[cost];
+    }
+
+    outputMap.add(layer, data);
+    return true;
+  }
+
+  /**
+   * @brief Load the costmap2d into the specified layer.
+   * 
+   * @param costmap2d : from this costmap type object
+   * @param layer : name of the layer to insert
+   * @param outputMap : to this costmap type object
+   * 
+   * @warning this does not lock the costmap2d object, you should take care to do so from outside this function.
+   **/
+  bool addLayerFromCostmap2d(costmap_2d::Costmap2DROS& costmap2d,
+                             const std::string& layer,
+                             MapType& outputMap)
+  {
+    return addLayerFromCostmap2d(*(costmap2d.getCostmap()), layer, outputMap);
+  }
+
+private:
+  template <typename TranslationTable>
+  void initializeCostTranslationTable(const TranslationTable& translation_table) {
+    translation_table.apply(costTranslationTable_);
+  }
+
+  std::vector<typename MapType::DataType> costTranslationTable_;
+};
+/*****************************************************************************
+** Trailers
+*****************************************************************************/
+
+} // namespace grid_map
+
+#endif /* grid_map_ros_COSTMAP_2D_CONVERTER_HPP_ */

--- a/grid_map_ros/include/grid_map_ros/Costmap2DConverter.hpp
+++ b/grid_map_ros/include/grid_map_ros/Costmap2DConverter.hpp
@@ -14,6 +14,9 @@
 
 #include <costmap_2d/costmap_2d.h>
 #include <costmap_2d/costmap_2d_ros.h>
+#include <grid_map_core/grid_map_core.hpp>
+#include <sstream>
+#include <tf/tf.h>
 #include <vector>
 
 /*****************************************************************************
@@ -87,7 +90,7 @@ class Costmap2DConverter
 public:
   /**
    * @brief Default constructor
-   * 
+   *
    * Initiliases the cost translation table with the default policy for the template
    * map type class.
    **/
@@ -98,7 +101,7 @@ public:
 
   /**
    * @brief Initialise the cost translation table with the user specified translation table functor.
-   * 
+   *
    * @param translation_table : user provided translation table
    */
   template <typename TranslationTable>
@@ -106,18 +109,18 @@ public:
   {
     initializeCostTranslationTable(translation_table);
   }
-  
+
   virtual ~Costmap2DConverter()
   {
   }
 
-  void initializeFromCostmap2d(costmap_2d::Costmap2DROS& costmap2d, MapType& outputMap)
+  void initializeFromCostmap2D(costmap_2d::Costmap2DROS& costmap2d, MapType& outputMap)
   {
-    initializeFromCostmap2d(*(costmap2d.getCostmap()), outputMap);
+    initializeFromCostmap2D(*(costmap2d.getCostmap()), outputMap);
     outputMap.setFrameId(costmap2d.getGlobalFrameID());
   }
 
-  void initializeFromCostmap2d(const costmap_2d::Costmap2D& costmap2d, MapType& outputMap)
+  void initializeFromCostmap2D(const costmap_2d::Costmap2D& costmap2d, MapType& outputMap)
   {
     const double resolution = costmap2d.getResolution();
     Length length(costmap2d.getSizeInCellsX()*resolution, costmap2d.getSizeInCellsY()*resolution);
@@ -129,14 +132,14 @@ public:
 
   /**
    * @brief Load the costmap2d into the specified layer.
-   * 
+   *
    * @param costmap2d : from this costmap type object
    * @param layer : name of the layer to insert
    * @param outputMap : to this costmap type object
-   * 
+   *
    * @warning this does not lock the costmap2d object, you should take care to do so from outside this function.
    **/
-  bool addLayerFromCostmap2d(const costmap_2d::Costmap2D& costmap2d,
+  bool addLayerFromCostmap2D(const costmap_2d::Costmap2D& costmap2d,
                              const std::string& layer,
                              MapType& outputMap)
   {
@@ -147,12 +150,12 @@ public:
       return false;
     }
     if (!outputMap.getStartIndex().isZero()) {
-      ROS_ERROR("CostmapConverter::fromCostmap2d() does not support non-zero start indices!");
+      ROS_ERROR("CostmapConverter::fromCostmap2D() does not support non-zero start indices!");
       return false;
     }
     // Copy data.
     // Reverse iteration is required because of different conventions
-    // between Costmap2d and grid map.
+    // between Costmap2D and grid map.
     typename MapType::Matrix data(size(0), size(1));
     const size_t nCells = outputMap.getSize().prod();
     for (size_t i = 0, j = nCells - 1; i < nCells; ++i, --j) {
@@ -166,18 +169,148 @@ public:
 
   /**
    * @brief Load the costmap2d into the specified layer.
-   * 
+   *
    * @param costmap2d : from this costmap type object
    * @param layer : name of the layer to insert
    * @param outputMap : to this costmap type object
-   * 
+   *
    * @warning this does not lock the costmap2d object, you should take care to do so from outside this function.
    **/
-  bool addLayerFromCostmap2d(costmap_2d::Costmap2DROS& costmap2d,
+  bool addLayerFromCostmap2D(costmap_2d::Costmap2DROS& costmap2d,
                              const std::string& layer,
                              MapType& outputMap)
   {
-    return addLayerFromCostmap2d(*(costmap2d.getCostmap()), layer, outputMap);
+    return addLayerFromCostmap2D(*(costmap2d.getCostmap()), layer, outputMap);
+  }
+
+  bool initializeFromCostmap2DAtRobotPose(costmap_2d::Costmap2DROS& costmap2d,
+                                          const Length& geometry,
+                                          MapType& outputMap)
+  {
+    /****************************************
+    ** Properties
+    ****************************************/
+    const double resolution = costmap2d.getCostmap()->getResolution();
+
+    /****************************************
+    ** Get the Robot Pose Transform
+    ****************************************/
+    tf::Stamped<tf::Pose> tf_pose;
+    if(!costmap2d.getRobotPose(tf_pose))
+    {
+      std::ostringstream error_message;
+      error_message << "could not get robot pose, is it actually published?";
+      ROS_ERROR_STREAM("CostmapConverter::" << error_message.str());
+      return false;
+      // throw std::runtime_error(error_message.str());
+    }
+
+    /****************************************
+    ** Where is the New Costmap Origin?
+    ****************************************/
+    Position robot_position(tf_pose.getOrigin().x() , tf_pose.getOrigin().y());
+    Position ros_map_origin(costmap2d.getCostmap()->getOriginX(), costmap2d.getCostmap()->getOriginY());
+    Position new_cost_map_origin;
+
+    // Note:
+    //   You cannot directly use the robot pose as the new 'costmap centre'
+    //   since the underlying grid is not necessarily exactly aligned with
+    //   that (two cases to consider, rolling window and globally fixed).
+    //
+    // Relevant diagrams:
+    //  - https://github.com/ethz-asl/grid_map
+
+    // float versions of the cell co-ordinates, use static_cast<int> to get the indices
+    Position robot_cell_position = (robot_position - ros_map_origin)/resolution;
+
+    // if there is an odd number of cells
+    //   centre of the new grid map in the centre of the current cell
+    // if there is an even number of cells
+    //   centre of the new grid map at the closest vertex between cells
+    // of the current cell
+    int number_of_cells_x = geometry.x()/resolution;
+    int number_of_cells_y = geometry.y()/resolution;
+    if ( number_of_cells_x % 2 ) { // odd
+      new_cost_map_origin(0) = std::floor(robot_cell_position.x())*resolution + resolution/2.0 + ros_map_origin.x();
+    } else {
+      new_cost_map_origin(0) = std::round(robot_cell_position.x())*resolution + ros_map_origin.x();
+    }
+    if ( number_of_cells_y % 2 ) { // odd
+      new_cost_map_origin(1) = std::floor(robot_cell_position.y())*resolution + resolution/2.0 + ros_map_origin.y();
+    } else {
+      new_cost_map_origin(1) = std::round(robot_cell_position.y())*resolution + ros_map_origin.y();
+    }
+
+    /****************************************
+    ** Asserts
+    ****************************************/
+    // TODO check the robot pose is in the window
+    // TODO check the geometry fits within the costmap2d window
+
+    /****************************************
+    ** Initialise the Output Map
+    ****************************************/
+    outputMap.setFrameId(costmap2d.getGlobalFrameID());
+    outputMap.setTimestamp(ros::Time::now().toNSec());
+    outputMap.setGeometry(geometry, resolution, new_cost_map_origin);
+    return true;
+  }
+
+  bool addLayerFromCostmap2DAtRobotPose(costmap_2d::Costmap2DROS& costmap2d,
+                                        const std::string& layer,
+                                        MapType& outputMap)
+  {
+    /****************************************
+    ** Asserts
+    ****************************************/
+    if ( outputMap.getResolution() != costmap2d.getCostmap()->getResolution()) {
+      std::ostringstream error_message;
+      error_message << "Costmap2D and output map have different resolutions!";
+      ROS_ERROR_STREAM("CostmapConverter::" << error_message.str());
+      return false;
+    }
+    // 1) would be nice to check the output map centre has been initialised where it should be
+    //      i.e. the robot pose didn't move since or the initializeFrom wasn't called
+    //    but this would mean listening to tf's again and anyway, it gets shifted to make sure
+    //    the costmaps align, so these wouldn't be exactly the same anyway
+    // 2) check the geometry fits inside the costmap2d subwindow is done below
+
+    /****************************************
+    ** Properties
+    ****************************************/
+    const double resolution = costmap2d.getCostmap()->getResolution();
+//    const Length geometry = outputMap.getLength();
+//    // Note: don't use getSizeInMeters() here - it doesn't give the actual grid size...for
+//    // some reason they designed it so that it cuts it short at the centre of the last cell
+//    //            e.g. 10 cells, resolution 1.0 -> getSizeInMeters() == 9.5
+//    double original_size_x = costmap2d.getCostmap()->getSizeInCellsX() * resolution;
+//    double original_size_y = costmap2d.getCostmap()->getSizeInCellsY() * resolution;
+//    // Note: don't use getSizeInMeters() here - it doesn't give the actual grid size...for
+//    // some reason they designed it so that it cuts it short at the centre of the last cell
+//    //            e.g. 10 cells, resolution 1.0 -> getSizeInMeters() == 9.5
+    const Length geometry = outputMap.getLength();
+
+    /****************************************
+    ** Copy Data
+    ****************************************/
+    bool is_valid_window = false;
+    costmap_2d::Costmap2D costmap_subwindow;
+    is_valid_window = costmap_subwindow.copyCostmapWindow(
+                            *(costmap2d.getCostmap()),
+                            outputMap.getPosition().x() - geometry.x() / 2.0, // subwindow_bottom_left_x
+                            outputMap.getPosition().y() - geometry.y() / 2.0, // subwindow_bottom_left_y
+                            geometry.x(),
+                            geometry.y());
+    if ( !is_valid_window ) {
+      // handle differently - e.g. copy the internal part only and lethal elsewhere, but other parts would have to handle being outside too
+      std::ostringstream error_message;
+      error_message << "subwindow landed outside the costmap, aborting";
+      ROS_ERROR_STREAM("CostmapConverter::" << error_message.str());
+      return false;
+      throw std::out_of_range(error_message.str());
+    }
+    addLayerFromCostmap2D(costmap_subwindow, layer, outputMap);
+    return true;
   }
 
 private:

--- a/grid_map_ros/include/grid_map_ros/grid_map_ros.hpp
+++ b/grid_map_ros/include/grid_map_ros/grid_map_ros.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <grid_map_core/grid_map_core.hpp>
+#include <grid_map_ros/Costmap2DConverter.hpp>
 #include <grid_map_ros/GridMapRosConverter.hpp>
 #include <grid_map_ros/PolygonRosConverter.hpp>
 #include <grid_map_ros/GridMapMsgHelpers.hpp>

--- a/grid_map_ros/package.xml
+++ b/grid_map_ros/package.xml
@@ -19,5 +19,6 @@
   <depend>geometry_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>rosbag</depend>
+  <depend>costmap_2d</depend>
   <depend>visualization_msgs</depend>
 </package>

--- a/grid_map_ros/package.xml
+++ b/grid_map_ros/package.xml
@@ -20,5 +20,6 @@
   <depend>cv_bridge</depend>
   <depend>rosbag</depend>
   <depend>costmap_2d</depend>
+  <depend>tf</depend>
   <depend>visualization_msgs</depend>
 </package>

--- a/grid_map_ros/src/GridMapRosConverter.cpp
+++ b/grid_map_ros/src/GridMapRosConverter.cpp
@@ -226,6 +226,7 @@ bool GridMapRosConverter::fromOccupancyGrid(const nav_msgs::OccupancyGrid& occup
     return false;
   }
 
+  // TODO: Split to `initializeFrom` and `from` as for Costmap2d.
   if ((gridMap.getSize() != size).any() || gridMap.getResolution() != resolution
       || (gridMap.getLength() != length).any() || gridMap.getPosition() != position
       || gridMap.getFrameId() != frameId || !gridMap.getStartIndex().isZero()) {

--- a/grid_map_ros/test/Costmap2DConverterTest.cpp
+++ b/grid_map_ros/test/Costmap2DConverterTest.cpp
@@ -1,0 +1,77 @@
+/*
+ * Costmap2DConverterTest.cpp
+ *
+ *  Created on: Nov 23, 2016
+ *      Author: Peter Fankhauser
+ *	 Institute: ETH Zurich, Robotic Systems Lab
+ */
+
+// Grid map
+#include <grid_map_core/GridMap.hpp>
+#include <grid_map_ros/Costmap2DConverter.hpp>
+
+// Gtest
+#include <gtest/gtest.h>
+
+// Eigen
+#include <Eigen/Core>
+
+using namespace grid_map;
+
+TEST(Costmap2DConversion, initializeFromCostmap2D)
+{
+  Costmap2DConverter<GridMap> costmap2dConverter;
+  // Create Costmap2D.
+  costmap_2d::Costmap2D costmap2d(8, 5, 1.0, 2.0, 3.0);
+
+  // Convert to grid map.
+  GridMap gridMap;
+  costmap2dConverter.initializeFromCostmap2D(costmap2d, gridMap);
+
+  // Check map info.
+  // Different conventions: Costmap2D returns the *centerpoint* of the last cell in the map.
+  Length length = gridMap.getLength() - Length::Constant(0.5 * gridMap.getResolution());
+  Length position = gridMap.getPosition() - 0.5 * gridMap.getLength().matrix();
+  EXPECT_EQ(costmap2d.getSizeInMetersX(), length.x());
+  EXPECT_EQ(costmap2d.getSizeInMetersY(), length.y());
+  EXPECT_EQ(costmap2d.getSizeInCellsX(), gridMap.getSize()[0]);
+  EXPECT_EQ(costmap2d.getSizeInCellsY(), gridMap.getSize()[1]);
+  EXPECT_EQ(costmap2d.getResolution(), gridMap.getResolution());
+  EXPECT_EQ(costmap2d.getOriginX(), position.x());
+  EXPECT_EQ(costmap2d.getOriginY(), position.y());
+}
+
+TEST(Costmap2DConversion, addLayerFromCostmap2D)
+{
+  Costmap2DConverter<GridMap> costmap2dConverter;
+
+  // Create Costmap2D.
+  costmap_2d::Costmap2D costmap2d(8, 5, 1.0, 2.0, 3.0);
+
+  // Create grid map.
+  const std::string layer("layer");
+  GridMap gridMap;
+  costmap2dConverter.initializeFromCostmap2D(costmap2d, gridMap);
+
+  // Set test data.
+  using TestValue = std::tuple<Position, unsigned char, double>;
+  std::vector<TestValue> testValues;
+  testValues.push_back(TestValue(Position(8.5, 4.5), 1, 1.0));
+  testValues.push_back(TestValue(Position(3.2, 5.1), 254, 100.0));
+  testValues.push_back(TestValue(Position(5.2, 7.8), 255, -1.0));
+
+  // Fill in test data to Costmap2D.
+  for (const auto& testValue : testValues) {
+    unsigned int xIndex, yIndex;
+    ASSERT_TRUE(costmap2d.worldToMap(std::get<0>(testValue).x(), std::get<0>(testValue).y(), xIndex, yIndex));
+    costmap2d.getCharMap()[costmap2d.getIndex(xIndex, yIndex)] = std::get<1>(testValue);
+  }
+
+  // Copy data.
+  costmap2dConverter.addLayerFromCostmap2D(costmap2d, layer, gridMap);
+
+  // Check data.
+  for (const auto& testValue : testValues) {
+    EXPECT_EQ(std::get<2>(testValue), gridMap.atPosition(layer, std::get<0>(testValue)));
+  }
+}


### PR DESCRIPTION
Started with the implementation in pull request #78 and extended it to accomodate:

* direct costmap2D -> cost_map translation (i.e. not 0.0 -> 100.0)
* conversions of subwindows around the costmap2DROS robot pose

Note that it also touched the core `GridMap` class to add some type traits that assist template methods work with either of the map types. I've a more complete set of `cost_map::CostMap` tests for this class in the `cost_map_ros` package.