### PR TITLE
Fixes transparency issue, where robots and other markers could not be…

### DIFF
--- a/grid_map_rviz_plugin/src/GridMapVisual.cpp
+++ b/grid_map_rviz_plugin/src/GridMapVisual.cpp
@@ -223,8 +223,18 @@ void GridMapVisual::computeVisualization(float alpha, bool showGridLines, bool f
 
   manualObject_->end();
   material_->getTechnique(0)->setLightingEnabled(false);
-  material_->getTechnique(0)->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
-  material_->getTechnique(0)->setDepthWriteEnabled(false);
+
+
+  if ( alpha < 0.9998 )
+  {
+    material_->getTechnique(0)->setSceneBlending( Ogre::SBT_TRANSPARENT_ALPHA );
+    material_->getTechnique(0)->setDepthWriteEnabled( false );
+  }
+  else
+  {
+    material_->getTechnique(0)->setSceneBlending( Ogre::SBT_REPLACE );
+    material_->getTechnique(0)->setDepthWriteEnabled( true );
+  }
 }
 
 void GridMapVisual::setFramePosition(const Ogre::Vector3& position)

--- a/grid_map_rviz_plugin/src/GridMapVisual.cpp
+++ b/grid_map_rviz_plugin/src/GridMapVisual.cpp
@@ -115,7 +115,7 @@ void GridMapVisual::computeVisualization(float alpha, bool showGridLines, bool f
 
   meshLines_->clear();
   if (showGridLines) {
-    meshLines_->setColor(0.0, 0.0, 0.0, 1.0);
+    meshLines_->setColor(0.0, 0.0, 0.0, alpha);
     meshLines_->setLineWidth(resolution / 10.0);
     meshLines_->setMaxPointsPerLine(2);
     size_t nLines = rows * (cols - 1) + cols * (rows - 1);

--- a/grid_map_rviz_plugin/src/GridMapVisual.cpp
+++ b/grid_map_rviz_plugin/src/GridMapVisual.cpp
@@ -224,7 +224,7 @@ void GridMapVisual::computeVisualization(float alpha, bool showGridLines, bool f
   manualObject_->end();
   material_->getTechnique(0)->setLightingEnabled(false);
   material_->getTechnique(0)->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
-  material_->getTechnique(0)->setDepthWriteEnabled(true);
+  material_->getTechnique(0)->setDepthWriteEnabled(false);
 }
 
 void GridMapVisual::setFramePosition(const Ogre::Vector3& position)

--- a/grid_map_rviz_plugin/src/GridMapVisual.cpp
+++ b/grid_map_rviz_plugin/src/GridMapVisual.cpp
@@ -154,17 +154,17 @@ void GridMapVisual::computeVisualization(float alpha, bool showGridLines, bool f
                 Ogre::Vector3(position(0), position(1), flatTerrain ? 0.0 : height));
             if (!flatColor) {
               float color = colorData(index(0), index(1));
-	      Ogre::ColourValue colorValue;
-	      if (mapLayerColor) {
-		Eigen::Vector3f colorVectorRGB;
-		grid_map::colorValueToVector(color, colorVectorRGB);
-		colorValue = Ogre::ColourValue(colorVectorRGB(0), colorVectorRGB(1), colorVectorRGB(2));		
-	      } else {
-		normalizeIntensity(color, minIntensity, maxIntensity);
-		colorValue =
-		    useRainbow ? (invertRainbow ?  getRainbowColor(1.0 - color) : getRainbowColor(color)) :
-			getInterpolatedColor(color, minColor, maxColor);
-	      }
+              Ogre::ColourValue colorValue;
+              if (mapLayerColor) {
+                Eigen::Vector3f colorVectorRGB;
+                grid_map::colorValueToVector(color, colorVectorRGB);
+                colorValue = Ogre::ColourValue(colorVectorRGB(0), colorVectorRGB(1), colorVectorRGB(2));
+              } else {
+                normalizeIntensity(color, minIntensity, maxIntensity);
+                colorValue =
+                    useRainbow ? (invertRainbow ?  getRainbowColor(1.0 - color) : getRainbowColor(color)) :
+                      getInterpolatedColor(color, minColor, maxColor);
+              }
               colors.push_back(colorValue);
             }
           }
@@ -224,16 +224,12 @@ void GridMapVisual::computeVisualization(float alpha, bool showGridLines, bool f
   manualObject_->end();
   material_->getTechnique(0)->setLightingEnabled(false);
 
-
-  if ( alpha < 0.9998 )
-  {
-    material_->getTechnique(0)->setSceneBlending( Ogre::SBT_TRANSPARENT_ALPHA );
-    material_->getTechnique(0)->setDepthWriteEnabled( false );
-  }
-  else
-  {
-    material_->getTechnique(0)->setSceneBlending( Ogre::SBT_REPLACE );
-    material_->getTechnique(0)->setDepthWriteEnabled( true );
+  if (alpha < 0.9998) {
+    material_->getTechnique(0)->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+    material_->getTechnique(0)->setDepthWriteEnabled(false);
+  } else {
+    material_->getTechnique(0)->setSceneBlending(Ogre::SBT_REPLACE);
+    material_->getTechnique(0)->setDepthWriteEnabled(true);
   }
 }
 


### PR DESCRIPTION
… seen through a transparent Grid_map.

fixes #68 

I'm not entirely sure what advantages/disadvantages setting DepthWrite gives you. However, changing it to false should fix the transparency issue.