### PR TITLE
Added comparison delta to ray tracing to make glancing intersection hits

### DIFF
--- a/grid_map_pcl/src/GridMapPclConverter.cpp
+++ b/grid_map_pcl/src/GridMapPclConverter.cpp
@@ -123,15 +123,20 @@ bool GridMapPclConverter::rayTriangleIntersect(
 
   if (r < 0) return false;
 
+  // Note(alexmillane): The addition of this comparison delta (not in the
+  // original algorithm) means that rays intersecting the edge of triangles are
+  // treated at hits.
+  constexpr float delta = 1e-5;
+
   const Eigen::Vector3f w = point + r * ray - a;
   const float denominator = u.dot(v) * u.dot(v) - u.dot(u) * v.dot(v);
   const float s_numerator = u.dot(v) * w.dot(v) - v.dot(v) * w.dot(u);
   const float s = s_numerator / denominator;
-  if (s < 0 || s > 1) return false;
+  if (s < (0 - delta) || s > (1 + delta)) return false;
 
   const float t_numerator = u.dot(v) * w.dot(u) - u.dot(u) * w.dot(v);
   const float t = t_numerator / denominator;
-  if (t < 0 || s + t > 1) return false;
+  if (t < (0 - delta) || s + t > (1 + delta)) return false;
 
   intersectionPoint = a + s * u + t * v;
 


### PR DESCRIPTION
As above. This is a small change but gives a big difference in the output map in some cases. This is particularly true in the case that mesh triangles happen to be generated on the same grid as the grid map, and the number of glancing ray casts is large. See the example below where the mesh was generated by voxblox.

Before:
![before](https://user-images.githubusercontent.com/671701/28078132-2be852e0-6664-11e7-984b-094eb04b46b2.png)

After:
![after](https://user-images.githubusercontent.com/671701/28078145-33b83396-6664-11e7-8e57-e1bb86aa4331.png)

