### PR TITLE
Fixing cost_map regression

### DIFF
--- a/grid_map_ros/CMakeLists.txt
+++ b/grid_map_ros/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
   rosbag
   tf
   visualization_msgs
+  grid_map_costmap_2d
 )
 
 ## System dependencies are found with CMake's conventions
@@ -49,6 +50,7 @@ catkin_package(
     rosbag
     tf
     visualization_msgs
+    grid_map_costmap_2d
   DEPENDS
 )
 
@@ -104,10 +106,9 @@ install(
 if(CATKIN_ENABLE_TESTING)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 ## Add gtest based cpp test target and link libraries
-catkin_add_gtest(
-	${PROJECT_NAME}-test
-	test/test_grid_map_ros.cpp
-	test/GridMapRosTest.cpp
+catkin_add_gtest(${PROJECT_NAME}-test
+  test/test_grid_map_ros.cpp
+  test/GridMapRosTest.cpp
 )
 endif()
 

--- a/grid_map_ros/include/grid_map_ros/Costmap2DConverter.hpp
+++ b/grid_map_ros/include/grid_map_ros/Costmap2DConverter.hpp
@@ -1,0 +1,11 @@
+/*
+ * Costmap2DConverter.hpp
+ *
+ *  Created on: Jul 25, 2017
+ *      Author: Péter Fankhauser
+ */
+
+#pragma once
+
+#warning "DEPRECATION WARNING: The file (`grid_map_ros/Costmap2DConverter.hpp`) is deprecated and will be deleted in the next version of Grid Map. Instead, use `grid_map_costmap_2d/Costmap2DConverter.hpp`."
+#include <grid_map_costmap_2d/grid_map_costmap_2d.hpp>

--- a/grid_map_ros/package.xml
+++ b/grid_map_ros/package.xml
@@ -21,4 +21,5 @@
   <depend>rosbag</depend>
   <depend>tf</depend>
   <depend>visualization_msgs</depend>
+  <depend>grid_map_costmap_2d</depend>
 </package>


### PR DESCRIPTION
Added backwards compatibility for costmap_2d conversion in grid_map_ros and marked it as deprecated.