### PR TITLE
Fix segfault in SpiralIterator the center is outside the map

### DIFF
--- a/grid_map_core/CMakeLists.txt
+++ b/grid_map_core/CMakeLists.txt
@@ -114,7 +114,8 @@ catkin_add_gtest(${PROJECT_NAME}-test
   test/SubmapIteratorTest.cpp
   test/PolygonIteratorTest.cpp
   test/PolygonTest.cpp
-  test/EigenPluginsTest.cpp)
+  test/EigenPluginsTest.cpp
+  test/SpiralIteratorTest.cpp)
 endif()
 
 if(TARGET ${PROJECT_NAME}-test)

--- a/grid_map_core/src/GridMapMath.cpp
+++ b/grid_map_core/src/GridMapMath.cpp
@@ -135,11 +135,11 @@ bool getIndexFromPosition(Index& index,
                           const Size& bufferSize,
                           const Index& bufferStartIndex)
 {
-  if (!checkIfPositionWithinMap(position, mapLength, mapPosition)) return false;
   Vector offset;
   getVectorToOrigin(offset, mapLength);
   Vector indexVector = ((position - offset - mapPosition).array() / resolution).matrix();
   index = getIndexFromIndexVector(indexVector, bufferSize, bufferStartIndex);
+  if (!checkIfPositionWithinMap(position, mapLength, mapPosition)) return false;
   return true;
 }
 

--- a/grid_map_core/src/iterators/SpiralIterator.cpp
+++ b/grid_map_core/src/iterators/SpiralIterator.cpp
@@ -28,8 +28,11 @@ SpiralIterator::SpiralIterator(const grid_map::GridMap& gridMap, const Eigen::Ve
   bufferSize_ = gridMap.getSize();
   gridMap.getIndex(center_, indexCenter_);
   nRings_ = std::ceil(radius_ / resolution_);
-  if (checkIfIndexWithinRange(indexCenter_, bufferSize_)) pointsRing_.push_back(indexCenter_);
-  else generateRing();
+  if (checkIfIndexWithinRange(indexCenter_, bufferSize_))
+    pointsRing_.push_back(indexCenter_);
+  else
+    while(pointsRing_.empty() && !isPastEnd())
+      generateRing();
 }
 
 SpiralIterator& SpiralIterator::operator =(const SpiralIterator& other)

--- a/grid_map_core/test/SpiralIteratorTest.cpp
+++ b/grid_map_core/test/SpiralIteratorTest.cpp
@@ -1,0 +1,41 @@
+/*
+ * SpiralIteratorTest.cpp
+ *
+ *  Created on: Jul 26, 2017
+ *      Author: Benjamin Scholz
+ *	 Institute: University of Hamburg, TAMS
+ */
+
+#include "grid_map_core/iterators/SpiralIterator.hpp"
+#include "grid_map_core/GridMap.hpp"
+
+// Eigen
+#include <Eigen/Core>
+
+// gtest
+#include <gtest/gtest.h>
+
+// Limits
+#include <cfloat>
+
+// Vector
+#include <vector>
+
+using namespace std;
+using namespace Eigen;
+using namespace grid_map;
+
+TEST(SpiralIterator, CenterOutOfMap)
+{
+  GridMap map( { "types" });
+  map.setGeometry(Length(8.0, 5.0), 1.0, Position(0.0, 0.0));
+  Position center(8.0, 0.0);
+  double radius = 5.0;
+
+  SpiralIterator iterator(map, center, radius);
+
+  Position iterator_position;
+  map.getPosition(*iterator, iterator_position);
+
+  EXPECT_TRUE(map.isInside(iterator_position));
+}


### PR DESCRIPTION
In case the center of the `SpiralIterator` happens to be outside the map
a segmentation fault occurs when trying to use the iterator.

In this case the index of the center was not computed,
because `getIndexFromPosition` returned false without changing
the value of the index. With this patch, the index is computed, but the function still
returns false when the position is outside the map.

Additionally, only the cells adjacent to the center were looked at in that case.
When these cells are outside the map too, dereferencing the pointer leads
to a segmentation fault. This was fixed by generating rings until a position inside the map is reached.