### PR TITLE
Fixed: Clamp changes were disregarded

### DIFF
--- a/grid_map_cv/include/grid_map_cv/GridMapCvConverter.hpp
+++ b/grid_map_cv/include/grid_map_cv/GridMapCvConverter.hpp
@@ -215,7 +215,7 @@ class GridMapCvConverter
     // Clamp outliers.
     grid_map::GridMap map = gridMap;
     map.get(layer) = map.get(layer).unaryExpr(grid_map::Clamp<float>(lowerValue, upperValue));
-    const grid_map::Matrix& data = gridMap[layer];
+    const grid_map::Matrix& data = map[layer];
 
     // Convert to image.
     bool isColor = false;


### PR DESCRIPTION
Bug has been noticed after converting a grid map and clamping the ray count to a reasonable number.
Converting the non clamped values produces the invalid picture.

![grid_map_count_max255_post_fix](https://user-images.githubusercontent.com/29129177/28676461-fbe8238e-72ea-11e7-8b37-e8e4049f60de.png)
![grid_map_count_max255_pre_fix](https://user-images.githubusercontent.com/29129177/28676468-fddb2d1c-72ea-11e7-8f91-9efc5ce80634.png)
