### PR TITLE
grid_map_core: Polygon triangulation checks number of vertices.

### DIFF
--- a/grid_map_core/src/Polygon.cpp
+++ b/grid_map_core/src/Polygon.cpp
@@ -208,8 +208,11 @@ std::vector<Polygon> Polygon::triangulate(const TriangulationMethods& method) co
 {
   // TODO Add more triangulation methods.
   // https://en.wikipedia.org/wiki/Polygon_triangulation
-  size_t nPolygons = vertices_.size() - 2;
   std::vector<Polygon> polygons;
+  if (vertices_.size() < 3)
+    return polygons;
+
+  size_t nPolygons = vertices_.size() - 2;
   polygons.reserve(nPolygons);
 
   if (nPolygons < 1) {


### PR DESCRIPTION
I found this potential issue while debugging [https://github.com/leggedrobotics/free_gait/pull/39](url).
This is only a suggestion and not needed to solve the free gait visualization issue.