### PR TITLE
Adds in dependencies on OpenCV. 

### DIFF
--- a/grid_map_cv/CMakeLists.txt
+++ b/grid_map_cv/CMakeLists.txt
@@ -10,6 +10,8 @@ find_package(catkin REQUIRED COMPONENTS
   filters
 )
 
+find_package(OpenCV 3 REQUIRED)
+
 ###################################
 ## catkin specific configuration ##
 ###################################
@@ -50,6 +52,7 @@ add_library(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
+  ${OpenCV_LIBRARIES}
 )
 
 add_dependencies(${PROJECT_NAME}

--- a/grid_map_cv/CMakeLists.txt
+++ b/grid_map_cv/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   filters
 )
 
-find_package(OpenCV 3 REQUIRED)
+find_package(OpenCV REQUIRED)
 
 ###################################
 ## catkin specific configuration ##

--- a/grid_map_cv/CMakeLists.txt
+++ b/grid_map_cv/CMakeLists.txt
@@ -10,7 +10,10 @@ find_package(catkin REQUIRED COMPONENTS
   filters
 )
 
-find_package(OpenCV REQUIRED)
+find_package(OpenCV REQUIRED
+  COMPONENTS
+  opencv_photo
+)
 
 ###################################
 ## catkin specific configuration ##
@@ -31,6 +34,7 @@ catkin_package(
     cv_bridge
     filters
   DEPENDS
+    OpenCV
 )
 
 ###########

--- a/grid_map_demos/CMakeLists.txt
+++ b/grid_map_demos/CMakeLists.txt
@@ -22,7 +22,9 @@ find_package(catkin REQUIRED COMPONENTS
   filters
 )
 
-find_package(OpenCV REQUIRED)
+find_package(OpenCV REQUIRED
+  COMPONENTS
+  opencv_highgui)
 
 find_package(octomap REQUIRED)
 

--- a/grid_map_demos/CMakeLists.txt
+++ b/grid_map_demos/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
   filters
 )
 
-find_package(OpenCV 3 REQUIRED)
+find_package(OpenCV REQUIRED)
 
 find_package(octomap REQUIRED)
 

--- a/grid_map_demos/CMakeLists.txt
+++ b/grid_map_demos/CMakeLists.txt
@@ -22,6 +22,8 @@ find_package(catkin REQUIRED COMPONENTS
   filters
 )
 
+find_package(OpenCV 3 REQUIRED)
+
 find_package(octomap REQUIRED)
 
 ###################################
@@ -148,6 +150,7 @@ target_link_libraries(
 target_link_libraries(
   opencv_demo
   ${catkin_LIBRARIES}
+  ${OpenCV_LIBRARIES}
 )
 
 target_link_libraries(

--- a/grid_map_ros/src/GridMapRosConverter.cpp
+++ b/grid_map_ros/src/GridMapRosConverter.cpp
@@ -444,7 +444,8 @@ bool GridMapRosConverter::saveToBag(const grid_map::GridMap& gridMap, const std:
 {
   grid_map_msgs::GridMap message;
   toMessage(gridMap, message);
-  ros::Time time(gridMap.getTimestamp());
+  ros::Time time;
+  time.fromNSec(gridMap.getTimestamp());
 
   if (!time.isValid() || time.isZero()) {
     if (!ros::Time::isValid()) ros::Time::init();


### PR DESCRIPTION
Previously all needed components were included by cv_bridge, but now cv_bridge does not include all opencv components, so they need to be explicitly added in other packages.

Specifically, about 3 months ago cv_bridge was updated to use
```
find_package(OpenCV 3 REQUIRED
COMPONENTS
    opencv_core
    opencv_imgproc
    opencv_imgcodecs
  CONFIG
)
```
instead of 
`find_package(OpenCV REQUIRED)`

https://github.com/ros-perception/vision_opencv/commit/8b5bbcbc1ce65734dc600695487909e0c67c1033

Previously, all of the components of OpenCV were included in the dependent libraries because of this; however, now only the listed libraries are there. So master failed to compile because the highgui library is not included. Doing another find_package in the dependent libraries lets you add in the missing (highgui) libraries.