### PR TITLE
Resolve for ignored qualifiers warnings

### DIFF
--- a/grid_map_ros/include/grid_map_ros/GridMapMsgHelpers.hpp
+++ b/grid_map_ros/include/grid_map_ros/GridMapMsgHelpers.hpp
@@ -23,7 +23,7 @@ namespace grid_map {
  * Returns the number of dimensions of the grid map.
  * @return number of dimensions.
  */
-const int nDimensions();
+int nDimensions();
 
 enum class StorageIndices {
     Column,


### PR DESCRIPTION
Resolve for ignored qualifiers that appear when built with `-Wignored-qualifiers` option