### PR TITLE
Possible master compilation fix (OpenCV lib issue)

### DIFF
--- a/grid_map_demos/CMakeLists.txt
+++ b/grid_map_demos/CMakeLists.txt
@@ -22,9 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
   filters
 )
 
-find_package(OpenCV REQUIRED
-  COMPONENTS
-  opencv_highgui)
+find_package(OpenCV REQUIRED)
 
 find_package(octomap REQUIRED)
 


### PR DESCRIPTION
Removes the components part of the grid_map_demos opencv find_package call