### PR TITLE
cmake fix typo eigen include dirS

### DIFF
--- a/grid_map_core/CMakeLists.txt
+++ b/grid_map_core/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 catkin_package(
   INCLUDE_DIRS
     include
-    ${EIGEN3_INCLUDE_DIR}
+    ${EIGEN3_INCLUDE_DIRS}
   LIBRARIES
     ${PROJECT_NAME}
   CATKIN_DEPENDS
@@ -49,7 +49,7 @@ catkin_package(
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIR}
+  ${EIGEN3_INCLUDE_DIRS}
 )
 
 ## Declare a cpp library


### PR DESCRIPTION
Fix typo in CmakeLists related to eigen include dir variable.

Not sure why but on my machine `EIGEN3_INCLUDE_DIR` is empty while `EIGEN3_INCLUDE_DIRS` has the include path properly defined.

Ubuntu 14.04 + ROS Indigo.