### PR TITLE
Fix expression for calculating traversability in grid_map_demos

### DIFF
--- a/grid_map_demos/config/filters_demo_filter_chain.yaml
+++ b/grid_map_demos/config/filters_demo_filter_chain.yaml
@@ -101,7 +101,7 @@ grid_map_filters:
     type: gridMapFilters/MathExpressionFilter
     params:
       output_layer: traversability
-      expression: 0.5 * (1.0 - (slope / 0.6)) + 0.5 * (1.0 - (roughness / 0.1))
+      expression: 0.5 * (1.0 - (slope * 0.6)) + 0.5 * (1.0 - (roughness * 0.1))
 
   # Set lower threshold on traversability.
   - name: traversability_lower_threshold


### PR DESCRIPTION
If I understood correctly, `slope` takes values in the range [0, pi/2], and the intention of the factor 0.6 is so that the values don't go over 1.0. Therefore, I think it should be a multiplication (3.14 / 2 * 0.6 ≈ 0.942). Please correct me if that isn't the case!