### PR TITLE
Change to tf2 for RViz plugin

### DIFF
--- a/grid_map_rviz_plugin/include/grid_map_rviz_plugin/modified/frame_manager.h
+++ b/grid_map_rviz_plugin/include/grid_map_rviz_plugin/modified/frame_manager.h
@@ -44,10 +44,10 @@
 #include <geometry_msgs/Pose.h>
 
 #ifndef Q_MOC_RUN
-#include <tf/message_filter.h>
+#include <tf2_ros/message_filter.h>
 #endif
 
-namespace tf
+namespace tf2_ros
 {
 class TransformListener;
 }
@@ -74,7 +74,7 @@ public:
   /** @brief Constructor
    * @param tf a pointer to tf::TransformListener (should not be used anywhere else because of thread safety)
    */
-  FrameManager(boost::shared_ptr<tf::TransformListener> tf = boost::shared_ptr<tf::TransformListener>());
+  FrameManager(boost::shared_ptr<tf2_ros::TransformListener> tf = boost::shared_ptr<tf2_ros::TransformListener>());
 
   /** @brief Destructor.
    *
@@ -171,7 +171,7 @@ public:
    * based on success or failure of the filter, including appropriate
    * error messages. */
   template<class M>
-  void registerFilterForTransformStatusCheck(tf::MessageFilter<M>* filter, Display* display)
+  void registerFilterForTransformStatusCheck(tf2_ros::MessageFilter<M>* filter, Display* display)
   {
     filter->registerCallback(boost::bind(&FrameManager::messageCallback<M>, this, _1, display));
     filter->registerFailureCallback(boost::bind(&FrameManager::failureCallback<M>, this, _1, _2, display));
@@ -181,10 +181,10 @@ public:
   const std::string& getFixedFrame() { return fixed_frame_; }
 
   /** @brief Return the tf::TransformListener used to receive transform data. */
-  tf::TransformListener* getTFClient() { return tf_.get(); }
+  tf2_ros::TransformListener* getTFClient() { return tf_.get(); }
 
   /** @brief Return a boost shared pointer to the tf::TransformListener used to receive transform data. */
-  const boost::shared_ptr<tf::TransformListener>& getTFClientPtr() { return tf_; }
+  const boost::shared_ptr<tf2_ros::TransformListener>& getTFClientPtr() { return tf_; }
 
   /** @brief Create a description of a transform problem.
    * @param frame_id The name of the frame with issues.
@@ -198,7 +198,7 @@ public:
   std::string discoverFailureReason(const std::string& frame_id,
                                     const ros::Time& stamp,
                                     const std::string& caller_id,
-                                    tf::FilterFailureReason reason);
+                                    tf2_ros::FilterFailureReason reason);
 
 Q_SIGNALS:
   /** @brief Emitted whenever the fixed frame changes. */
@@ -218,7 +218,7 @@ private:
   }
 
   template<class M>
-  void failureCallback(const ros::MessageEvent<M const>& msg_evt, tf::FilterFailureReason reason, Display* display)
+  void failureCallback(const ros::MessageEvent<M const>& msg_evt, tf2_ros::FilterFailureReason reason, Display* display)
   {
     boost::shared_ptr<M const> const &msg = msg_evt.getConstMessage();
     std::string authority = msg_evt.getPublisherName();
@@ -227,7 +227,7 @@ private:
   }
 
   void messageArrived(const std::string& frame_id, const ros::Time& stamp, const std::string& caller_id, Display* display);
-  void messageFailed(const std::string& frame_id, const ros::Time& stamp, const std::string& caller_id, tf::FilterFailureReason reason, Display* display);
+  void messageFailed(const std::string& frame_id, const ros::Time& stamp, const std::string& caller_id, tf2_ros::FilterFailureReason reason, Display* display);
 
   struct CacheKey
   {
@@ -265,7 +265,7 @@ private:
   boost::mutex cache_mutex_;
   M_Cache cache_;
 
-  boost::shared_ptr<tf::TransformListener> tf_;
+  boost::shared_ptr<tf2_ros::TransformListener> tf_;
   std::string fixed_frame_;
 
   bool pause_;

--- a/grid_map_rviz_plugin/include/grid_map_rviz_plugin/modified/message_filter_display.h
+++ b/grid_map_rviz_plugin/include/grid_map_rviz_plugin/modified/message_filter_display.h
@@ -23,9 +23,9 @@ class MessageFilterDisplayMod : public rviz::MessageFilterDisplay<MessageType>
 
   void onInitialize()
   {
-    MFDClass::tf_filter_ = new tf::MessageFilter<MessageType>(*MFDClass::context_->getTFClient(),
-                                                              MFDClass::fixed_frame_.toStdString(),
-                                                              10, MFDClass::update_nh_);
+    MFDClass::tf_filter_ = new tf2_ros::MessageFilter<MessageType>(*MFDClass::context_->getTF2BufferPtr(),
+                                                                   MFDClass::fixed_frame_.toStdString(),
+                                                                   10, MFDClass::update_nh_);
 
     MFDClass::tf_filter_->connectInput(MFDClass::sub_);
     MFDClass::tf_filter_->registerCallback(


### PR DESCRIPTION
As mentioned in  #171 - changing to `tf2` in the RViz plugin is required for it to work with ROS Melodic. Overall it is just a simple replace. Tested under Ubuntu 18.04.